### PR TITLE
Update get tx by hash

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -509,7 +509,9 @@ class NearProvider {
             // NB: provider.txStatus requires txHash to be a Uint8Array of
             // the base58 tx hash. Since txHash is hex, it is converted to
             // base58, and then turned into a Buffer
-            const { txHash, accountId } = utils.getTxHashAndAccountId(txHashAndAccountId);
+            let { txHash, accountId } = utils.getTxHashAndAccountId(txHashAndAccountId);
+
+            accountId = accountId || this.accountId;
 
             const { transaction_outcome: { block_hash }} = await this.nearProvider.txStatus(utils.hexToUint8(txHash), accountId);
             const block = await this._getBlock(block_hash, true);

--- a/src/utils.js
+++ b/src/utils.js
@@ -175,21 +175,21 @@ utils.convertTimestamp = function(value) {
 };
 
 /**
- * Splits hex string into txHash and accountId
+ * Splits hex string into txHash and accountId if both are passed through
  * Used by eth_getTransactionByHash, eth_getTransactionReceipt
- * @param {String} value hex string in format <txHash>:<accountId>
+ * @param {String} value hex string in format <txHash>:<accountId> or txHash
  * @returns {Object} Returns txHash and accountId as strings
  */
 utils.getTxHashAndAccountId = function(value) {
-    assert(
-        value.includes(':'),
-        'Must pass in hash and accountId separated by ":" <txHash:accountId>'
-    );
-    // Split value into txHash and accountId
-    const [ txHash, accountId ] = value.split(':');
+    if (value.includes(':')) {
+        // Split value into txHash and accountId
+        const [txHash, accountId] = value.split(':');
 
-    // Return object for convenience so we don't need to keep track of index order
-    return { txHash, accountId };
+        // Return object for convenience so we don't need to keep track of index order
+        return { txHash, accountId };
+    } else {
+        return { txHash: value, accountId: '' };
+    }
 };
 
 /**

--- a/test/near_provider.test.js
+++ b/test/near_provider.test.js
@@ -288,7 +288,7 @@ describe.skip('\n---- BLOCK & TRANSACTION QUERIES ----', () => {
         }
     }));
 
-    describe('getBlockNumber | eth_blockNumber', () => {
+    describe.skip('getBlockNumber | eth_blockNumber', () => {
         test('returns the most recent blockNumber', withWeb3(async (web) => {
             await waitForABlock();
 
@@ -298,7 +298,7 @@ describe.skip('\n---- BLOCK & TRANSACTION QUERIES ----', () => {
         }));
     });
 
-    describe(`getBlock |
+    describe.skip(`getBlock |
         eth_getBlockByHash,
         eth_getBlockByNumber`, () => {
 
@@ -365,7 +365,7 @@ describe.skip('\n---- BLOCK & TRANSACTION QUERIES ----', () => {
         }));
     });
 
-    describe(`getBlockTransactionCount |
+    describe.skip(`getBlockTransactionCount |
         eth_getBlockTransactionCountByHash,
         eth_getBlockTransactionCountByNumber`, () => {
 


### PR DESCRIPTION
Update `eth_getTransactionByHash` to use `accountId` if passed through or else defaults to `this.accountId`

Passes truffle tests on `near-evm-demo`

`truffle migrate --network near`