### PR TITLE
tests: cleanups

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -677,26 +677,19 @@ class NearProvider {
      */
     // TODO: Account for passed in gas
     async routeEthSendTransaction([txObj]) {
-        // console.log({txObj})
         try {
             let outcome;
             let val;
             const { to, value, data } = txObj;
-            console.log({value})
             if (value === undefined) {
-                console.log('value undefined')
                 val = new BN(0)
             } else {
-                console.log('value defined zzzz')
                 const remove = utils.remove0x(value)
-                console.log({remove})
                 val = new BN(remove, 16)
-                console.log({val})
             }
             // value === undefined
             //     ? new BN(0)
             //     : new BN(utils.remove0x(value), 16);
-            console.log('val here', val)
 
             // TODO: differentiate simple sends
             const functionCallData = {
@@ -706,10 +699,8 @@ class NearProvider {
                 gas: GAS_AMOUNT,
                 amount: val
             }
-            console.log('functionCallData', functionCallData)
 
             if (to === undefined) {
-                console.log('Deploying contract')
                 // Contract deployment.
                 outcome = await this.account.functionCall(
                     this.evm_contract,
@@ -719,7 +710,6 @@ class NearProvider {
                     val
                 );
             } else {
-                console.log('calling contract')
                 outcome = await this.account.functionCall(
                     this.evm_contract,
                     'call_contract',
@@ -730,7 +720,6 @@ class NearProvider {
             }
             return `${outcome.transaction_outcome.id}:${this.accountId}`;
         } catch (e) {
-            console.log('send transaction e', e)
             return e;
         }
     }

--- a/src/near_to_eth_objects.js
+++ b/src/near_to_eth_objects.js
@@ -121,9 +121,7 @@ nearToEth.transactionObj = async function(tx, txIndex) {
 // TODO: Is this chunks.gas_used or accumulated gas_burnt for each tx?
 nearToEth._getGasUsed = function(chunks) {
     const gasUsed = chunks.map((c) => c.gas_used);
-    // console.log({gasUsed})
     const accumulated = gasUsed.reduce((a, b) => a + b);
-    // console.log({accumulated})
     return accumulated;
 }
 
@@ -136,7 +134,6 @@ nearToEth._getGasUsed = function(chunks) {
  * @returns {Object} returns ETH block object
  */
 nearToEth.blockObj = async function(block, returnTxObjects, nearProvider) {
-    // console.log('-----nearToEth.blockObj');
     try {
         block = await this.hydrate.block(block, nearProvider);
 
@@ -162,10 +159,8 @@ nearToEth.blockObj = async function(block, returnTxObjects, nearProvider) {
             transactions = [];
         } else {
             if (!returnTxObjects) {
-                // console.log('Just hashes');
                 transactions = block.transactions.map((tx) => `${tx.hash }:${ tx.signer_id }`);
             } else {
-                // console.log('everything');
                 const hydratedTransactions = await hydrate.allTransactions(block, nearProvider);
 
                 const promiseArray = hydratedTransactions.map((tx, txIndex) => {
@@ -281,7 +276,6 @@ nearToEth.transactionReceiptObj = function(block, nearTxObj, nearTxObjIndex, acc
       destination = args.contract_address;
     } else {
         const receiver = utils.nearAccountToEvmAddress(transaction.receiver_id);
-        console.log({receiver})
         destination = receiver;
     }
 


### PR DESCRIPTION
This PR removes `console.log`s and all of the tests pass against a local `nearcore` node. One of the larger changes is that is uses the validator account/keys that are created at `~/.near/validator_key.json` instead of creating an account. There are still some `TODOs` left in the tests for testing different cases.

To reproduce, clone `nearcore` and run the commands:

```
$ make docker-nearcore
$ ./scripts/start_localnet.py
```

Then these tests can be ran against a local node. Would be ideal to have the node started up by the testsuite itself instead of having to start it externally.